### PR TITLE
Fix undo meta tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: minimal
 sudo: require
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: minimal
 sudo: require
+
 services:
   - docker
 
 before_script:
   - unset BUNDLE_GEMFILE
   - docker-compose run app bundle install
+  - docker-compose run app bundle exec appraisal install
+
 script:
   - docker-compose run app bundle exec rspec
   - docker-compose run app bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 before_script:
   - unset BUNDLE_GEMFILE
   - docker-compose run app bundle install
-  - docker-compose run app bundle exec appraisal install
 
 script:
   - docker-compose run app bundle exec rspec

--- a/lib/logux/meta.rb
+++ b/lib/logux/meta.rb
@@ -32,5 +32,30 @@ module Logux
     def id
       fetch('id')
     end
+
+    def undo_meta
+      self.class.new(undo_meta_hash)
+    end
+
+    private
+
+    RESEND_KEYS = %w[
+      users
+      nodes
+      channels
+    ].freeze
+
+    private_constant :RESEND_KEYS
+
+    def undo_meta_hash
+      { status: 'processed' }
+        .merge(slice(*RESEND_KEYS))
+        .merge(clients: clients)
+    end
+
+    def clients
+      result = [client_id]
+      key?('clients') ? (result + self['clients']) : result
+    end
   end
 end

--- a/lib/logux/node.rb
+++ b/lib/logux/node.rb
@@ -20,8 +20,10 @@ module Logux
       end
     end
 
+    NODE_ID_SIZE = 8
+
     def node_id
-      @node_id ||= "server:#{Nanoid.generate(size: 8)}"
+      @node_id ||= "server:#{Nanoid.generate(size: NODE_ID_SIZE)}"
     end
 
     private

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -91,7 +91,7 @@ module Logux
     def undo(meta, reason: nil, data: {})
       add(
         data.merge(type: 'logux/undo', id: meta.id, reason: reason),
-        Logux::Meta.new(clients: [meta.client_id])
+        meta.undo_meta
       )
     end
 

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -88,11 +88,11 @@ module Logux
       Logux::Add.new.call(commands)
     end
 
-    def undo(meta, reason: nil, data: {})
-      add(
-        data.merge(type: 'logux/undo', id: meta.id, reason: reason),
-        meta.undo_meta
-      )
+    def undo(meta, reason: nil, data: {}, action: nil)
+      undo_action = data.merge(type: 'logux/undo', id: meta.id)
+      undo_action[:reason] = reason if reason
+      undo_action[:action] = action if action
+      add(undo_action, meta.undo_meta)
     end
 
     def verify_request_meta_data(meta_params)

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -88,10 +88,9 @@ module Logux
       Logux::Add.new.call(commands)
     end
 
-    def undo(meta, reason: nil, data: {}, action: nil)
+    def undo(meta, reason: nil, data: {})
       undo_action = data.merge(type: 'logux/undo', id: meta.id)
       undo_action[:reason] = reason if reason
-      undo_action[:action] = action if action
       add(undo_action, meta.undo_meta)
     end
 

--- a/logux-rack.gemspec
+++ b/logux-rack.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '~> 2.0'
   spec.add_dependency 'rest-client', '>= 1.7.3', '< 3'
   spec.add_dependency 'sinatra', '>= 2.0', '< 3'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'

--- a/spec/logux/meta_spec.rb
+++ b/spec/logux/meta_spec.rb
@@ -93,7 +93,6 @@ describe Logux::Meta do
         {
           'users' => %w[user],
           'nodes' => %w[node],
-          'reasons' => %w[reason],
           'channels' => %w[channel]
         }
       end

--- a/spec/logux/meta_spec.rb
+++ b/spec/logux/meta_spec.rb
@@ -84,4 +84,38 @@ describe Logux::Meta do
       end
     end
   end
+
+  describe '#undo_meta' do
+    subject(:undo_meta) { meta.undo_meta }
+
+    context 'with resend keys' do
+      let(:attributes) do
+        {
+          'users' => %w[user],
+          'nodes' => %w[node],
+          'reasons' => %w[reason],
+          'channels' => %w[channel]
+        }
+      end
+
+      it 'copies re-send keys' do
+        expect(undo_meta).to include(attributes)
+      end
+    end
+
+    context 'with clients list' do
+      let(:clients_list) { %w[client] }
+      let(:attributes) { { 'clients' => clients_list } }
+
+      it 'appends client ids' do
+        expect(undo_meta['clients']).to eq([meta.client_id] + clients_list)
+      end
+    end
+
+    context 'without clients list' do
+      it 'contains client id' do
+        expect(undo_meta['clients']).to eq([meta.client_id])
+      end
+    end
+  end
 end

--- a/spec/logux/node_spec.rb
+++ b/spec/logux/node_spec.rb
@@ -22,7 +22,6 @@ describe Logux::Node do
       end
 
       it('returns 1 in sequence') do
-        puts id_pattern(sequence: 1)
         expect(action_id).to match(id_pattern(sequence: 1))
       end
     end

--- a/spec/logux/node_spec.rb
+++ b/spec/logux/node_spec.rb
@@ -5,12 +5,14 @@ require 'spec_helper'
 describe Logux::Node do
   let(:node) { described_class.instance }
 
+  def id_pattern(sequence: /\d+/)
+    /^[0-9]{13} server:.{#{Logux::Node::NODE_ID_SIZE}} #{sequence}$/
+  end
+
   describe '#generate_action_id' do
     subject(:action_id) { node.generate_action_id }
 
-    it 'returns correct id' do
-      expect(action_id).to match(/^[0-9]{13} server:.{8} 0$/)
-    end
+    it('returns correct id') { expect(action_id).to match(id_pattern) }
 
     context 'with action at the same time', timecop: true do
       before do
@@ -19,8 +21,9 @@ describe Logux::Node do
         node.generate_action_id
       end
 
-      it 'returns 1 in sequence' do
-        expect(action_id).to match(/^[0-9]{13} server:.{8} 1$/)
+      it('returns 1 in sequence') do
+        puts id_pattern(sequence: 1)
+        expect(action_id).to match(id_pattern(sequence: 1))
       end
     end
   end
@@ -28,9 +31,7 @@ describe Logux::Node do
   describe '#node_id' do
     subject(:node_id) { node.node_id }
 
-    it 'generates nanoid' do
-      expect(node_id).not_to be_empty
-    end
+    it('generates nanoid') { expect(node_id).not_to be_empty }
 
     it "doesn't change from call to call" do
       expect(node_id).to eq(node.node_id)


### PR DESCRIPTION
➡️ Moved from https://github.com/logux/logux_rails/pull/76 (After recent `logux_rails` refactoring `Logux.undo` and other core features were moved to Rails-agnostic `logux-rack` gem. So this patch belongs here now.)

This patch updates meta for the `undo` command, following the [reference implementation](https://github.com/logux/server/blob/master/base-server.js#L676-L682).

References:

- Original issue: https://github.com/logux/logux_rails/issues/73
- [Reference JS implementation](https://github.com/logux/server/blob/master/base-server.js#L676-L682)
- [Reference spec](https://github.com/logux/server/blob/master/test/base-server.test.js#L615)
- [Logux actions spec](https://github.com/logux/logux/blob/f643d847a8d1b2c439b292c15a1e6d2bbb7332a3/3-concepts/2-action.md)
