### PR TITLE
Add protocol 3

### DIFF
--- a/lib/logux/action_caller.rb
+++ b/lib/logux/action_caller.rb
@@ -18,6 +18,8 @@ module Logux
     rescue Logux::UnknownActionError, Logux::UnknownChannelError => e
       logger.warn(e)
       format(nil)
+    rescue => e
+      raise Logux::WithMetaError(e.message, meta: meta)
     end
 
     protected

--- a/lib/logux/add.rb
+++ b/lib/logux/add.rb
@@ -2,14 +2,14 @@
 
 module Logux
   class Add
-    attr_reader :client, :version, :password
+    attr_reader :client, :version, :secret
 
     def initialize(client: Logux::Client.new,
                    version: Logux::PROTOCOL_VERSION,
-                   password: Logux.configuration.password)
+                   secret: Logux.configuration.secret)
       @client = client
       @version = version
-      @password = password
+      @secret = secret
     end
 
     def call(commands)
@@ -25,7 +25,7 @@ module Logux
     def prepare_data(commands)
       {
         version: PROTOCOL_VERSION,
-        password: password,
+        secret: secret,
         commands: commands.map do |command|
           action = command.first
           meta = command[1]

--- a/lib/logux/error_renderer.rb
+++ b/lib/logux/error_renderer.rb
@@ -11,29 +11,29 @@ module Logux
     def message
       case exception
       when Logux::WithMetaError
-        build_message(exception, exception.meta.id)
+        build_message(exception, [exception.meta.id, backtrace(exception)])
       when Logux::UnauthorizedError
-        build_message(exception, exception.message)
+        build_message(exception, [exception.message])
       when StandardError
         # some runtime error that should be fixed
-        render_stardard_error(exception)
+        ['error', backtrace(exception)]
       end
     end
 
     private
 
-    def render_stardard_error(exception)
-      if Logux.configuration.render_backtrace_on_error
-        ['error', exception.message + "\n" + exception.backtrace.join("\n")]
-      else
-        ['error', 'Please check server logs for more information']
+    def backtrace(exception)
+      unless Logux.configuration.render_backtrace_on_error
+        return 'Please check server logs for more information'
       end
+
+      [exception.message, exception.backtrace].flatten.compact.join("\n")
     end
 
     def build_message(exception, additional_info)
       [
         exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
-        additional_info
+        *additional_info
       ]
     end
   end

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -59,7 +59,7 @@ module Logux
     logger
     logux_host
     on_error
-    password
+    secret
     render_backtrace_on_error
     verify_authorized
   ]
@@ -95,14 +95,14 @@ module Logux
     end
 
     def verify_request_meta_data(meta_params)
-      if configuration.password.nil?
-        logger.warn(%(Please, add password for logux server:
+      if configuration.secret.nil?
+        logger.warn(%(Please, add secret for logux server:
                             Logux.configure do |c|
-                              c.password = 'your-password'
+                              c.secret = 'your-secret'
                             end))
       end
-      auth = configuration.password == meta_params&.dig('password')
-      raise UnauthorizedError, 'Incorrect password' unless auth
+      auth = configuration.secret == meta_params&.dig('secret')
+      raise UnauthorizedError, 'Incorrect secret' unless auth
     end
 
     def process_batch(stream:, batch:)

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -13,7 +13,7 @@ require 'singleton'
 module Logux
   include Configurations
 
-  PROTOCOL_VERSION = 1
+  PROTOCOL_VERSION = 3
 
   class WithMetaError < StandardError
     attr_reader :meta

--- a/lib/logux/rack/app.rb
+++ b/lib/logux/rack/app.rb
@@ -37,7 +37,7 @@ module Logux
       end
 
       def meta_params
-        logux_params&.slice('version', 'password')
+        logux_params&.slice('version', 'secret')
       end
 
       def handle_processing_errors(logux_stream, exception)

--- a/spec/factories/logux_params_factory.rb
+++ b/spec/factories/logux_params_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     initialize_with do
       {
         version: attributes[:protocol_version] || Logux::PROTOCOL_VERSION,
-        password: attributes[:password] || 'secret',
+        secret: attributes[:secret] || 'secret',
         commands: attributes[:commands]
       }
     end
@@ -49,7 +49,7 @@ FactoryBot.define do
       initialize_with do
         build(
           :logux_params,
-          password: attributes[:password],
+          secret: attributes[:secret],
           commands: [
             build(:subscribe_command, channel: 'post/123'),
             build(:add_command)

--- a/spec/logux/client_spec.rb
+++ b/spec/logux/client_spec.rb
@@ -11,7 +11,7 @@ describe Logux::Client do
   let(:params) do
     {
       version: Logux::PROTOCOL_VERSION,
-      password: nil,
+      secret: nil,
       commands: commands
     }
   end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -113,8 +113,8 @@ describe Logux, timecop: true do
         Logux.configuration.logger = fake_logger
       end
 
-      it 'warn if password is empty' do
-        described_class.verify_request_meta_data(password: nil)
+      it 'warn if secret is empty' do
+        described_class.verify_request_meta_data(secret: nil)
         expect(Logux.configuration.logger).to have_received(:warn)
       end
     end

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -9,7 +9,7 @@ describe 'Request logux server' do
     before { request_logux }
 
     context 'when authorized' do
-      let(:logux_params) { build(:logux_batch_params, password: password) }
+      let(:logux_params) { build(:logux_batch_params, secret: secret) }
 
       it 'returns approved chunk' do
         expect(last_response).to logux_approved('219_856_768 clientid 0')
@@ -24,8 +24,8 @@ describe 'Request logux server' do
       end
     end
 
-    context 'when password wrong' do
-      let(:logux_params) { build(:logux_batch_params, password: 'wrong') }
+    context 'when secret wrong' do
+      let(:logux_params) { build(:logux_batch_params, secret: 'wrong') }
 
       it 'returns error' do
         expect(last_response).to logux_unauthorized

--- a/spec/requests/request_without_action_spec.rb
+++ b/spec/requests/request_without_action_spec.rb
@@ -17,7 +17,7 @@ describe 'Request logux server without action' do
 
       it 'returns unknownAction' do
         expect(JSON.parse(last_response.body)).to include(
-          ['unknownAction', '219_856_768 clientid 0']
+          ['unknownAction', '219_856_768 clientid 0', /Unable to find/]
         )
       end
     end

--- a/spec/requests/request_without_subscribe_spec.rb
+++ b/spec/requests/request_without_subscribe_spec.rb
@@ -20,7 +20,7 @@ describe 'Request logux server without subscribe' do
 
       it 'returns unknownChannel' do
         expect(JSON.parse(last_response.body)).to include(
-          ['unknownChannel', '219_856_768 clientid 0']
+          ['unknownChannel', '219_856_768 clientid 0', /Unable to find/]
         )
       end
     end

--- a/spec/requests/request_without_subscribe_spec.rb
+++ b/spec/requests/request_without_subscribe_spec.rb
@@ -6,7 +6,7 @@ describe 'Request logux server without subscribe' do
   include_context 'with request'
 
   let(:logux_params) do
-    build(:logux_subscribe_params, password: password, channel: channel)
+    build(:logux_subscribe_params, secret: secret, channel: channel)
   end
 
   context 'when verify_authorized=true' do

--- a/spec/support/request.rb
+++ b/spec/support/request.rb
@@ -6,9 +6,9 @@ shared_context 'with request' do
   subject(:request_logux) { post('/logux', logux_params.to_json) }
 
   before do
-    Logux.configure { |config| config.password = 'secret' }
+    Logux.configure { |config| config.secret = 'secret' }
   end
 
   let(:app) { Logux::Rack::App }
-  let(:password) { Logux.configuration.password }
+  let(:secret) { Logux.configuration.secret }
 end


### PR DESCRIPTION
I've made a draft for #9, but there are several questions:

1. `UnauthorizedError` is currently sent as `['unauthorized', message]`, is it needed to be sent with meta.id too, as `['unauthorized', meta.id, message]`?
2. `UnknownActionError` or `UnknownChannelError` are now `['unknownChannel', meta.id]`. Should it be unified to `['unknownChannel', meta.id, stack]`?
3. This question may be silly, but how is it supposed to answer with a 500 HTTP code, while it communicates via WebSockets and not HTTP? Should the 500 code be placed in the answer's body somehow?