### PR TITLE
Feature/protocol 3

### DIFF
--- a/lib/logux/add.rb
+++ b/lib/logux/add.rb
@@ -2,14 +2,14 @@
 
 module Logux
   class Add
-    attr_reader :client, :version, :password
+    attr_reader :client, :version, :secret
 
     def initialize(client: Logux::Client.new,
                    version: Logux::PROTOCOL_VERSION,
-                   password: Logux.configuration.password)
+                   secret: Logux.configuration.secret)
       @client = client
       @version = version
-      @password = password
+      @secret = secret
     end
 
     def call(commands)
@@ -25,7 +25,7 @@ module Logux
     def prepare_data(commands)
       {
         version: PROTOCOL_VERSION,
-        password: password,
+        secret: secret,
         commands: commands.map do |command|
           action = command.first
           meta = command[1]

--- a/lib/logux/error_renderer.rb
+++ b/lib/logux/error_renderer.rb
@@ -10,31 +10,32 @@ module Logux
 
     def message
       case exception
+      when UnknownActionError, UnknownChannelError
+        [
+          exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
+          exception.meta.id
+        ]
+      when UnauthorizedError
+        [exception.class.name.demodulize.camelize(:lower).gsub(/Error/, '')]
       when Logux::WithMetaError
-        build_message(exception, exception.meta.id)
-      when Logux::UnauthorizedError
-        build_message(exception, exception.message)
+        [
+          'error',
+          exception.meta.id,
+          stacktrace(exception)
+        ]
       when StandardError
-        # some runtime error that should be fixed
-        render_stardard_error(exception)
+        ['error', stacktrace(exception)]
       end
     end
 
     private
 
-    def render_stardard_error(exception)
+    def stacktrace(exception)
       if Logux.configuration.render_backtrace_on_error
-        ['error', exception.message + "\n" + exception.backtrace.join("\n")]
+        [exception.message, exception.backtrace&.join("\n")].compact.join("\n")
       else
-        ['error', 'Please check server logs for more information']
+        'Please check server logs for more information'
       end
-    end
-
-    def build_message(exception, additional_info)
-      [
-        exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
-        additional_info
-      ]
     end
   end
 end

--- a/lib/logux/error_renderer.rb
+++ b/lib/logux/error_renderer.rb
@@ -11,29 +11,26 @@ module Logux
     def message
       case exception
       when UnknownActionError, UnknownChannelError
-        [
-          exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
-          exception.meta.id
-        ]
+        [action_response, exception.meta.id]
       when Logux::WithMetaError
-        [
-          'error',
-          exception.meta.id,
-          stacktrace(exception)
-        ]
+        ['error', exception.meta.id, stacktrace]
       when StandardError
-        ['error', stacktrace(exception)]
+        ['error', stacktrace]
       end
     end
 
     private
 
-    def stacktrace(exception)
+    def stacktrace
       if Logux.configuration.render_backtrace_on_error
         [exception.message, exception.backtrace&.join("\n")].compact.join("\n")
       else
         'Please check server logs for more information'
       end
+    end
+
+    def action_response
+      exception.class.name.demodulize.camelize(:lower).gsub(/Error/, '')
     end
   end
 end

--- a/lib/logux/error_renderer.rb
+++ b/lib/logux/error_renderer.rb
@@ -15,8 +15,6 @@ module Logux
           exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
           exception.meta.id
         ]
-      when UnauthorizedError
-        [exception.class.name.demodulize.camelize(:lower).gsub(/Error/, '')]
       when Logux::WithMetaError
         [
           'error',

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -60,7 +60,7 @@ module Logux
     logger
     logux_host
     on_error
-    password
+    secret
     render_backtrace_on_error
     verify_authorized
   ]
@@ -96,14 +96,14 @@ module Logux
     end
 
     def verify_request_meta_data(meta_params)
-      if configuration.password.nil?
-        logger.warn(%(Please, add password for logux server:
+      if configuration.secret.nil?
+        logger.warn(%(Please, add secret for logux server:
                             Logux.configure do |c|
-                              c.password = 'your-password'
+                              c.secret = 'your-secret'
                             end))
       end
-      auth = configuration.password == meta_params&.dig('password')
-      raise UnauthorizedError, 'Incorrect password' unless auth
+      auth = configuration.secret == meta_params&.dig('secret')
+      raise UnauthorizedError, 'Incorrect secret' unless auth
     end
 
     def process_batch(stream:, batch:)

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -26,7 +26,6 @@ module Logux
 
   UnknownActionError = Class.new(WithMetaError)
   UnknownChannelError = Class.new(WithMetaError)
-  UnauthorizedError = Class.new(StandardError)
   ParameterMissingError = Class.new(StandardError)
 
   autoload :Client, 'logux/client'
@@ -102,8 +101,12 @@ module Logux
                               c.secret = 'your-secret'
                             end))
       end
-      auth = configuration.secret == meta_params&.dig('secret')
-      raise UnauthorizedError, 'Incorrect secret' unless auth
+
+      configuration.secret == meta_params&.dig('secret')
+    end
+
+    def verify_protocol(meta_params)
+      Logux::PROTOCOL_VERSION == meta_params&.dig('version')
     end
 
     def process_batch(stream:, batch:)

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -27,6 +27,7 @@ module Logux
   UnknownActionError = Class.new(WithMetaError)
   UnknownChannelError = Class.new(WithMetaError)
   ParameterMissingError = Class.new(StandardError)
+  RequestError = Class.new(StandardError)
 
   autoload :Client, 'logux/client'
   autoload :Meta, 'logux/meta'
@@ -94,7 +95,7 @@ module Logux
       add(undo_action, meta.undo_meta)
     end
 
-    def verify_request_meta_data(meta_params)
+    def secret_is_valid?(meta_params)
       if configuration.secret.nil?
         logger.warn(%(Please, add secret for logux server:
                             Logux.configure do |c|
@@ -105,7 +106,7 @@ module Logux
       configuration.secret == meta_params&.dig('secret')
     end
 
-    def verify_protocol(meta_params)
+    def protocol_is_valid?(meta_params)
       Logux::PROTOCOL_VERSION == meta_params&.dig('version')
     end
 

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -95,7 +95,7 @@ module Logux
       add(undo_action, meta.undo_meta)
     end
 
-    def secret_is_valid?(meta_params)
+    def valid_secret?(meta_params)
       if configuration.secret.nil?
         logger.warn(%(Please, add secret for logux server:
                             Logux.configure do |c|
@@ -106,8 +106,12 @@ module Logux
       configuration.secret == meta_params&.dig('secret')
     end
 
-    def protocol_is_valid?(meta_params)
+    def valid_protocol?(meta_params)
       Logux::PROTOCOL_VERSION == meta_params&.dig('version')
+    end
+
+    def valid_body?(params)
+      params.is_a?(Hash)
     end
 
     def process_batch(stream:, batch:)

--- a/lib/logux/rack.rb
+++ b/lib/logux/rack.rb
@@ -13,7 +13,7 @@ require 'singleton'
 module Logux
   include Configurations
 
-  PROTOCOL_VERSION = 1
+  PROTOCOL_VERSION = 3
 
   class WithMetaError < StandardError
     attr_reader :meta

--- a/lib/logux/rack/app.rb
+++ b/lib/logux/rack/app.rb
@@ -37,7 +37,7 @@ module Logux
       end
 
       def meta_params
-        logux_params&.slice('version', 'password')
+        logux_params&.slice('version', 'secret')
       end
 
       def handle_processing_errors(logux_stream, exception)

--- a/lib/logux/test/helpers.rb
+++ b/lib/logux/test/helpers.rb
@@ -62,12 +62,6 @@ module Logux
         )
       end
 
-      def logux_unauthorized(meta = nil)
-        Logux::Test::Matchers::ResponseChunks.new(
-          meta: meta, includes: ['unauthorized']
-        )
-      end
-
       def logux_denied(meta = nil)
         Logux::Test::Matchers::ResponseChunks.new(
           meta: meta, includes: ['denied']

--- a/lib/logux/test/helpers.rb
+++ b/lib/logux/test/helpers.rb
@@ -9,6 +9,10 @@ module Logux
         end
       end
 
+      def eq_body(body)
+        Logux::Test::Matchers::ResponseBody.new(body)
+      end
+
       def logux_store
         Logux::Test::Store.instance.data
       end

--- a/lib/logux/test/matchers.rb
+++ b/lib/logux/test/matchers.rb
@@ -5,6 +5,7 @@ module Logux
     module Matchers
       autoload :SendToLogux, 'logux/test/matchers/send_to_logux'
       autoload :ResponseChunks, 'logux/test/matchers/response_chunks'
+      autoload :ResponseBody, 'logux/test/matchers/response_body'
     end
   end
 end

--- a/lib/logux/test/matchers/response_body.rb
+++ b/lib/logux/test/matchers/response_body.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Logux
+  module Test
+    module Matchers
+      class ResponseBody < Base
+        def initialize(body)
+          @body = body
+        end
+
+        def matches?(actual)
+          @actual = actual
+          actual.body == body
+        end
+
+        def failure_message
+          "expected that '#{actual.body}' to equal '#{body}'"
+        end
+
+        private
+
+        attr_reader :body, :actual
+      end
+    end
+  end
+end

--- a/spec/factories/logux_params_factory.rb
+++ b/spec/factories/logux_params_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     initialize_with do
       {
         version: attributes[:protocol_version] || Logux::PROTOCOL_VERSION,
-        password: attributes[:password] || 'secret',
+        secret: attributes[:secret] || 'secret',
         commands: attributes[:commands]
       }
     end
@@ -49,7 +49,7 @@ FactoryBot.define do
       initialize_with do
         build(
           :logux_params,
-          password: attributes[:password],
+          secret: attributes[:secret],
           commands: [
             build(:subscribe_command, channel: 'post/123'),
             build(:add_command)

--- a/spec/logux/client_spec.rb
+++ b/spec/logux/client_spec.rb
@@ -11,7 +11,7 @@ describe Logux::Client do
   let(:params) do
     {
       version: Logux::PROTOCOL_VERSION,
-      password: nil,
+      secret: nil,
       commands: commands
     }
   end

--- a/spec/logux/error_renderer_spec.rb
+++ b/spec/logux/error_renderer_spec.rb
@@ -23,13 +23,6 @@ describe Logux::ErrorRenderer do
       it { is_expected.to eq(['unknownChannel', action_id]) }
     end
 
-    context 'when UnauthorizedError' do
-      let(:exception) { Logux::UnauthorizedError.new(message) }
-      let(:message) { 'test' }
-
-      it { is_expected.to eq(['unauthorized']) }
-    end
-
     context 'when StandardError' do
       let(:exception) { StandardError.new(message) }
       let(:error_message) { "#{message}\n#{exception.backtrace.join("\n")}" }

--- a/spec/logux/error_renderer_spec.rb
+++ b/spec/logux/error_renderer_spec.rb
@@ -33,13 +33,19 @@ describe Logux::ErrorRenderer do
       end
 
       it { is_expected.to eq(['error', error_message]) }
+    end
 
-      context 'when render_backtrace_on_error is false' do
-        before do
-          Logux.configuration.render_backtrace_on_error = false
-        end
+    context 'when render_backtrace_on_error is false' do
+      let(:exception) { StandardError.new }
 
-        it { is_expected.to eq(['error', 'Please check server logs for more information']) }
+      before do
+        Logux.configuration.render_backtrace_on_error = false
+      end
+
+      it do
+        is_expected.to eq(
+          ['error', 'Please check server logs for more information']
+        )
       end
     end
   end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -113,8 +113,8 @@ describe Logux, timecop: true do
         Logux.configuration.logger = fake_logger
       end
 
-      it 'warn if password is empty' do
-        described_class.verify_request_meta_data(password: nil)
+      it 'warn if secret is empty' do
+        described_class.verify_request_meta_data(secret: nil)
         expect(Logux.configuration.logger).to have_received(:warn)
       end
     end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -114,7 +114,7 @@ describe Logux, timecop: true do
       end
 
       it 'warn if secret is empty' do
-        described_class.verify_request_meta_data(secret: nil)
+        described_class.secret_is_valid?(secret: nil)
         expect(Logux.configuration.logger).to have_received(:warn)
       end
     end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -114,7 +114,7 @@ describe Logux, timecop: true do
       end
 
       it 'warn if secret is empty' do
-        described_class.secret_is_valid?(secret: nil)
+        described_class.valid_secret?(secret: nil)
         expect(Logux.configuration.logger).to have_received(:warn)
       end
     end

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -9,7 +9,7 @@ describe 'Request logux server' do
     before { request_logux }
 
     context 'when authorized' do
-      let(:logux_params) { build(:logux_batch_params, password: password) }
+      let(:logux_params) { build(:logux_batch_params, secret: secret) }
 
       it 'returns approved chunk' do
         expect(last_response).to logux_approved('219_856_768 clientid 0')
@@ -28,8 +28,8 @@ describe 'Request logux server' do
       end
     end
 
-    context 'when password wrong' do
-      let(:logux_params) { build(:logux_batch_params, password: 'wrong') }
+    context 'when secret wrong' do
+      let(:logux_params) { build(:logux_batch_params, secret: 'wrong') }
 
       it 'returns error' do
         expect(last_response).to logux_unauthorized

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -5,11 +5,37 @@ require 'spec_helper'
 describe 'Request logux server' do
   include_context 'with request'
 
+  context 'when secret is wrong' do
+    before { request_logux }
+    let(:logux_params) { build(:logux_params, secret: 'wrong') }
+
+    it 'returns 403' do
+      expect(last_response).to be_forbidden
+    end
+
+    it 'returns message and backtrace' do
+      expect(last_response.body).to eq('Wrong secret')
+    end
+  end
+
+  context 'when protocol is not supported' do
+    before { request_logux }
+    let(:logux_params) { build(:logux_params, protocol_version: -1) }
+
+    it 'returns 400' do
+      expect(last_response).to be_bad_request
+    end
+
+    it 'returns message and backtrace' do
+      expect(last_response.body).to eq('Back-end protocol version is not supported')
+    end
+  end
+
   context 'when authorization required' do
     before { request_logux }
 
     context 'when authorized' do
-      let(:logux_params) { build(:logux_batch_params, secret: secret) }
+      let(:logux_params) { build(:logux_batch_params) }
 
       it 'returns approved chunk' do
         expect(last_response).to logux_approved('219_856_768 clientid 0')
@@ -25,18 +51,6 @@ describe 'Request logux server' do
 
       it 'returns correct body' do
         expect(last_response).to logux_forbidden
-      end
-    end
-
-    context 'when secret wrong' do
-      let(:logux_params) { build(:logux_batch_params, secret: 'wrong') }
-
-      it 'returns 500' do
-        expect(last_response).to be_server_error
-      end
-
-      it 'returns message and backtrace' do
-        expect(last_response.body).to include('Incorrect secret')
       end
     end
   end

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -31,8 +31,12 @@ describe 'Request logux server' do
     context 'when secret wrong' do
       let(:logux_params) { build(:logux_batch_params, secret: 'wrong') }
 
-      it 'returns error' do
-        expect(last_response).to logux_unauthorized
+      it 'returns 500' do
+        expect(last_response).to be_server_error
+      end
+
+      it 'returns message and backtrace' do
+        expect(last_response.body).to include('Incorrect secret')
       end
     end
   end

--- a/spec/requests/request_logux_server_spec.rb
+++ b/spec/requests/request_logux_server_spec.rb
@@ -11,7 +11,7 @@ describe 'Request logux server' do
 
     it { is_expected.to be_forbidden }
 
-    it { is_expected.to eq_body('Wrong secret') }
+    it { is_expected.to eq_body(Logux::Rack::App::ERROR[:secret]) }
   end
 
   context 'when body is not a json' do
@@ -19,7 +19,7 @@ describe 'Request logux server' do
 
     it { is_expected.to be_bad_request }
 
-    it { is_expected.to eq_body('Wrong body') }
+    it { is_expected.to eq_body(Logux::Rack::App::ERROR[:body]) }
   end
 
   context 'when protocol is not supported' do
@@ -27,7 +27,7 @@ describe 'Request logux server' do
 
     it { is_expected.to be_bad_request }
 
-    it { is_expected.to eq_body('Back-end protocol version is not supported') }
+    it { is_expected.to eq_body(Logux::Rack::App::ERROR[:protocol]) }
   end
 
   context 'when authorization required' do

--- a/spec/requests/request_without_action_spec.rb
+++ b/spec/requests/request_without_action_spec.rb
@@ -17,7 +17,7 @@ describe 'Request logux server without action' do
 
       it 'returns unknownAction' do
         expect(JSON.parse(last_response.body).first).to include(
-          *['unknownAction', '219_856_768 clientid 0']
+          'unknownAction', '219_856_768 clientid 0'
         )
       end
     end

--- a/spec/requests/request_without_action_spec.rb
+++ b/spec/requests/request_without_action_spec.rb
@@ -16,8 +16,8 @@ describe 'Request logux server without action' do
       let(:action) { 'notexists/create' }
 
       it 'returns unknownAction' do
-        expect(JSON.parse(last_response.body)).to include(
-          ['unknownAction', '219_856_768 clientid 0']
+        expect(JSON.parse(last_response.body).first).to include(
+          *['unknownAction', '219_856_768 clientid 0']
         )
       end
     end

--- a/spec/requests/request_without_subscribe_spec.rb
+++ b/spec/requests/request_without_subscribe_spec.rb
@@ -6,7 +6,7 @@ describe 'Request logux server without subscribe' do
   include_context 'with request'
 
   let(:logux_params) do
-    build(:logux_subscribe_params, password: password, channel: channel)
+    build(:logux_subscribe_params, secret: secret, channel: channel)
   end
 
   context 'when verify_authorized=true' do

--- a/spec/support/request.rb
+++ b/spec/support/request.rb
@@ -6,9 +6,9 @@ shared_context 'with request' do
   subject(:request_logux) { post('/logux', logux_params.to_json) }
 
   before do
-    Logux.configure { |config| config.password = 'secret' }
+    Logux.configure { |config| config.secret = 'secret' }
   end
 
   let(:app) { Logux::Rack::App }
-  let(:password) { Logux.configuration.password }
+  let(:secret) { Logux.configuration.secret }
 end


### PR DESCRIPTION
Made changes to implement spec for protocol v3 https://github.com/logux/logux-rack/issues/9.

@ai I need your help with this. I read the [request on cultofmartians](https://cultofmartians.com/tasks/logux-rack-backend3.html) and [the review on former PR](https://github.com/logux/logux-rack/pull/10). Here are my questions:

1. I removed the stream and replace it with the plain response because it's not possible to return 500 if the stream already started. Is this ok?
2. I found only one case when it has to return 500. It's when we process `verify_request_meta_data`, rest of the things will be rescued. Am I correct?
3. You mentioned that logux backend protocol has no answer `unauthorized` https://github.com/logux/logux-rack/pull/10. What should happen when the secret does not match?
